### PR TITLE
$input_parameters cant be empty array in execute function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,23 @@
 {
-    "name": "herrera-io/pdo-log",
+    "name": "hgraca/pdo-log",
     "description": "A simple way to log PDO queries and execution times.",
     "keywords": ["pdo", "log", "debug"],
-    "homepage": "http://github.com/herrera-io/php-pdo-log",
+    "homepage": "http://github.com/hgraca/php-pdo-log",
     "license": "MIT",
     "authors": [
         {
             "name": "Kevin Herrera",
             "email": "kevin@herrera.io",
             "homepage": "http://kevin.herrera.io"
+        },
+        {
+            "name": "Herberto Graca",
+            "email": "herberto.graca@gmail.com",
+            "homepage": "http://www.hgraca.eu"
         }
     ],
     "support": {
-        "issues": "https://github.com/herrera-io/php-pdo-log/issues"
+        "issues": "https://github.com/hgraca/php-pdo-log/issues"
     },
     "require": {
         "php": ">=5.3.3",

--- a/src/lib/Herrera/Pdo/PdoStatement.php
+++ b/src/lib/Herrera/Pdo/PdoStatement.php
@@ -98,17 +98,14 @@ class PdoStatement
      */
     public function execute(array $input_parameters = array())
     {
-        $start = microtime(true);
-        $result = $this->statement->execute($input_parameters);
+        $start  = microtime(true);
+        $result = $this->statement->execute((empty($input_parameters)) ? null : $input_parameters);
 
         $this->pdo->addLog(
             array(
-                'query' => $this->statement->queryString,
-                'time' => microtime(true) - $start,
-                'values' => array_merge(
-                    $this->binds,
-                    $input_parameters
-                ),
+                'query'  => $this->statement->queryString,
+                'time'   => microtime(true) - $start,
+                'values' => array_merge($this->binds, $input_parameters),
             )
         );
 


### PR DESCRIPTION
when $input_parameters is empty array it removes bindings. It must be null.
